### PR TITLE
[Refactor] 리프레시 토큰 재발급 요청 실패 시 무한 루프 문제 해결

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -1,36 +1,40 @@
-// src/api/auth.js
 import axios from 'axios'
 import { useAuthStore } from '@/stores/auth'
 
-// axios 인스턴스 생성
+// 일반 요청용 인스턴스
 const api = axios.create({
   baseURL: 'http://localhost:8080',
   withCredentials: true
 })
 
-// 응답 인터셉터: accessToken 만료 시 자동 재발급
+// 인터셉터 미적용된 리프레시 토큰 재발급용 (리프레시 토큰 재발급 요청 무한 루프 방지)
+const rawApi = axios.create({
+  baseURL: 'http://localhost:8080',
+  withCredentials: true
+})
+
+// 인터셉터
 api.interceptors.response.use(
   response => response,
   async error => {
     const originalRequest = error.config
 
-    // accessToken 만료로 인한 401이고, 재시도한 적 없다면
-    if (error.response?.status === 401 && !originalRequest.__isRetry) {
-      originalRequest.__isRetry = true
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true
 
       const auth = useAuthStore()
       try {
-        const refreshRes = await api.post('/employee/refresh-token')
-
+        const refreshRes = await rawApi.post('/employee/refresh-token')
         const newAccessToken = refreshRes.headers['authorization']?.split(' ')[1]
+
         if (newAccessToken) {
           auth.setAccessToken(newAccessToken)
           originalRequest.headers['Authorization'] = `Bearer ${newAccessToken}`
-          return api(originalRequest) // 원래 요청 재시도
+          return api(originalRequest)
         }
       } catch (refreshError) {
         auth.clearToken()
-        window.location.href = '/' // 로그인 페이지로 리다이렉트
+        window.location.href = '/login'
         return Promise.reject(refreshError)
       }
     }

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -32,22 +32,6 @@ export const useAuthStore = defineStore('auth', {
       this.userInfo = null
       localStorage.removeItem('access_token')
       localStorage.removeItem('userInfo')
-    },
-    async refreshToken() {
-      try {
-        const res = await api.post('/employee/refresh-token')
-        const newToken = res.headers['authorization']?.split(' ')[1]
-        if (newToken) {
-          this.setAccessToken(newToken)
-          return newToken
-        } else {
-          throw new Error('No access token in response')
-        }
-      } catch (e) {
-        this.clearToken()
-        window.location.href = '/login'
-        throw e
-      }
     }
   }
 })

--- a/src/views/user/LoginView.vue
+++ b/src/views/user/LoginView.vue
@@ -89,21 +89,16 @@ const login = async () => {
 
     const token = res.headers['authorization']?.split(' ')[1];
     if (!token) {
-      console.warn('⚠️ accessToken이 응답에 포함되지 않았습니다.');
+      console.warn('accessToken이 응답에 포함되지 않았습니다.');
       return;
     }
 
     auth.setAccessToken(token);
     auth.setUserInfo(res.data);
-
     router.push('/');
   } catch (e) {
-    console.warn('🚨 로그인 실패:', e);
-    if (e.response?.data?.message) {
-      alert(e.response.data.message);
-    } else {
-      alert('로그인 요청에 실패하였습니다.');
-    }
+    const msg = e.response?.data?.message || '로그인 요청에 실패하였습니다.';
+    alert(msg);
   }
 };
 </script>


### PR DESCRIPTION
## 📌연관된 이슈

> close #116 

## 📝작업 내용

> accessToken이 만료되었을 때 Axios 응답 인터셉터가 무한 루프로 반복 호출하던 문제 해결
> originalRequest.__isRetry 플래그를 도입해 재시도 여부를 제어하고, refresh 실패 시 토큰을 초기화한 뒤 
> 로그인 페이지로 리다이렉트하도록 처리
> 로그인 실패 시 백엔드에서 전달된 메시지가 alert 창에 잘 노출되도록 로그인 에러 핸들링을 개선

### 스크린샷 (선택)

<img width="1077" alt="image" src="https://github.com/user-attachments/assets/2e51803d-26fa-47f3-a0da-507793e1dc05" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!!
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
