### PR TITLE
[Refactor] 로그인 상태 관리 기능 수정

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,5 +1,5 @@
 <template>
-  <header class="header">
+  <header class="header" v-if="user">
     <!-- 로고 -->
     <div class="left" @click="goHome">
       <img src="/logo_text.svg" alt="logo" class="logo" />
@@ -95,7 +95,7 @@ const goToMypage = () => {
 const logout = async () => {
   const token = auth.accessToken;
   if (!token) {
-    console.warn("⚠️ accessToken이 없어서 로그아웃 요청 건너뜀");
+    console.warn("accessToken이 없어서 로그아웃 요청 건너뜀");
     return;
   }
 
@@ -111,7 +111,7 @@ const logout = async () => {
       }
     );
   } catch (e) {
-    console.warn("🚨 로그아웃 중 오류:", e.message);
+    console.warn("로그아웃 중 오류:", e.message);
   } finally {
     auth.clearToken();
     router.push("/login");

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import router from './router'
 import { createPinia } from 'pinia'
 import { useAuthStore } from '@/stores/auth'
 import '@vueup/vue-quill/dist/vue-quill.snow.css';
+import api from '@/api/auth'
 
 const app = createApp(App)
 app.use(createPinia())
@@ -26,13 +27,14 @@ const tryRefreshAndLoadUser = async () => {
         },
         withCredentials: true
       })
+      
       auth.setUserInfo(res.data)
     } catch (err) {
       console.error('[userInfo 복구 실패]', err)
       auth.clearToken()
     }
   } else if (!auth.accessToken) {
-    // accessToken도 없는 경우 → refreshToken으로 재발급 시도
+    // accessToken도 없는 경우 → refreshToken으로 재발급
     try {
       const res = await api.post('/auth/refresh-token', null, {
         withCredentials: true
@@ -59,3 +61,5 @@ const tryRefreshAndLoadUser = async () => {
 }
 
 app.mount('#app')
+
+tryRefreshAndLoadUser()

--- a/src/main.js
+++ b/src/main.js
@@ -16,4 +16,46 @@ if (!auth.accessToken && localStorage.getItem('access_token')) {
   auth.setAccessToken(localStorage.getItem('access_token'))
 }
 
+const tryRefreshAndLoadUser = async () => {
+  if (auth.accessToken && !auth.userInfo) {
+    // accessToken은 있으나 userInfo가 없는 경우 → 마이페이지 호출
+    try {
+      const res = await api.get('/employee/mypage', {
+        headers: {
+          Authorization: `Bearer ${auth.accessToken}`
+        },
+        withCredentials: true
+      })
+      auth.setUserInfo(res.data)
+    } catch (err) {
+      console.error('[userInfo 복구 실패]', err)
+      auth.clearToken()
+    }
+  } else if (!auth.accessToken) {
+    // accessToken도 없는 경우 → refreshToken으로 재발급 시도
+    try {
+      const res = await api.post('/auth/refresh-token', null, {
+        withCredentials: true
+      })
+      const newToken = res.headers['authorization']?.split(' ')[1]
+
+      if (newToken) {
+        auth.setAccessToken(newToken)
+
+        const userRes = await api.get('/employee/mypage', {
+          headers: {
+            Authorization: `Bearer ${newToken}`
+          },
+          withCredentials: true
+        })
+        auth.setUserInfo(userRes.data)
+      }
+    } catch (err) {
+      console.warn('[refresh-token 재발급 실패]', err)
+      auth.clearToken()
+      window.location.href = '/login'
+    }
+  }
+}
+
 app.mount('#app')

--- a/src/stores/auth.js
+++ b/src/stores/auth.js
@@ -3,7 +3,7 @@ import { defineStore } from 'pinia'
 export const useAuthStore = defineStore('auth', {
   state: () => ({
     accessToken: localStorage.getItem('access_token') || null,
-    userInfo: JSON.parse(localStorage.getItem('userInfo')) || null
+    userInfo: null
   }),
   actions: {
     setAccessToken(token) {
@@ -13,25 +13,21 @@ export const useAuthStore = defineStore('auth', {
     },
     setUserInfo(info) {
       this.userInfo = info
-      localStorage.setItem('userInfo', JSON.stringify(info))
     },
     updateProfileImage(profilePath) {
       if (this.userInfo) {
         this.userInfo.profilePath = profilePath
-        localStorage.setItem('userInfo', JSON.stringify(this.userInfo))
       }
     },
     updateUserName(name) {
       if (this.userInfo) {
         this.userInfo.name = name
-        localStorage.setItem('userInfo', JSON.stringify(this.userInfo))
       }
     },
     clearToken() {
       this.accessToken = null
       this.userInfo = null
       localStorage.removeItem('access_token')
-      localStorage.removeItem('userInfo')
     }
   }
 })


### PR DESCRIPTION
## 📌연관된 이슈

> close #125 

## 📝작업 내용

> 로그인 사용자 인증 정보 관리 방식 변경

- userInfo를 localStorage에 저장하지 않고 pinia에만 보관
- 앱 로딩 시 accessToken이 없을 경우 refreshToken으로 자동 재발급 시도
- 재발급 성공 시 userInfo를 함께 복구
- 실패 시 로그아웃 처리 및 로그인 페이지로 리다이렉트

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!!
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
