### PR TITLE
[Feat] 영업부 매출 관리 대시보드 페이지 및 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "@vueup/vue-quill": "^1.2.0",
     "axios": "^1.9.0",
+    "echarts": "^5.6.0",
     "pinia": "^3.0.2",
     "vue": "^3.5.13",
+    "vue-echarts": "^7.0.3",
     "vue-router": "^4.5.1"
   },
   "devDependencies": {

--- a/src/components/salesDashboard/MonthQuarterSalesCard.vue
+++ b/src/components/salesDashboard/MonthQuarterSalesCard.vue
@@ -1,0 +1,77 @@
+<template>
+  <div class="month-quarter-sales-card">
+    <div class="sales-block">
+      <div class="title">이번 달 매출</div>
+      <div class="value" v-if="!loadingMonth">{{ formatCurrency(monthTotal) }}</div>
+      <div class="value" v-else>로딩중...</div>
+    </div>
+    <div class="sales-block">
+      <div class="title">이번 분기 매출</div>
+      <div class="value" v-if="!loadingQuarter">{{ formatCurrency(quarterTotal) }}</div>
+      <div class="value" v-else>로딩중...</div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import api from '@/api/auth'
+
+const monthTotal = ref(null)
+const quarterTotal = ref(null)
+const loadingMonth = ref(true)
+const loadingQuarter = ref(true)
+
+onMounted(async () => {
+  try {
+    const resMonth = await api.get('/dashboard/sales/total?period=month')
+    monthTotal.value = resMonth.data.totalAmount
+  } catch (e) {
+    monthTotal.value = 0
+  } finally {
+    loadingMonth.value = false
+  }
+
+  try {
+    const resQuarter = await api.get('/dashboard/sales/total?period=quarter')
+    quarterTotal.value = resQuarter.data.totalAmount
+  } catch (e) {
+    quarterTotal.value = 0
+  } finally {
+    loadingQuarter.value = false
+  }
+})
+
+function formatCurrency(val) {
+  if (val == null) return '-'
+  if (val >= 1e8) return (val / 1e8).toFixed(1) + '억원'
+  if (val >= 1e4) return (val / 1e4).toFixed(1) + '만원'
+  return val.toLocaleString() + '원'
+}
+</script>
+
+<style scoped>
+.month-quarter-sales-card {
+  display: flex;
+  flex-direction: row;
+  gap: 24px;
+  height: 100%;
+  justify-content: center;
+}
+.sales-block {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 0;
+  flex: 1 1 0;
+  justify-content: center;
+}
+.title {
+  font-size: 18px;
+  color: #333;
+  margin-bottom: 8px;
+}
+.value {
+  font-size: 28px;
+  font-weight: bold;
+}
+</style> 

--- a/src/components/salesDashboard/TeamSalesBarChart.vue
+++ b/src/components/salesDashboard/TeamSalesBarChart.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script setup>
-import { ref, watch, onMounted, onUnmounted, computed } from 'vue'
+import { ref, watch, onMounted, onUnmounted, computed, defineEmits } from 'vue'
 import api from '@/api/auth'
 
 const props = defineProps({
@@ -22,6 +22,8 @@ const loading = ref(true)
 const error = ref(false)
 const teamNames = ref([])
 const teamAmounts = ref([])
+
+const emit = defineEmits(['totalAmount'])
 
 const chartTitle = computed(() => {
   if (props.periodType === 'month') {
@@ -72,6 +74,11 @@ const fetchData = async () => {
 
 onMounted(fetchData)
 watch(() => [props.year, props.periodType, props.periodValue], fetchData)
+
+watch(teamAmounts, (newVal) => {
+  const total = newVal.reduce((sum, v) => sum + v, 0)
+  emit('totalAmount', total)
+})
 
 const barOption = computed(() => ({
   tooltip: { trigger: 'axis' },

--- a/src/components/salesDashboard/TeamSalesBarChart.vue
+++ b/src/components/salesDashboard/TeamSalesBarChart.vue
@@ -1,0 +1,129 @@
+<template>
+  <div class="team-sales-bar-chart">
+    <div class="chart-title">{{ chartTitle }}</div>
+    <v-chart v-show="!loading && !error" :option="barOption" autoresize style="height:320px;" />
+    <div v-if="loading">로딩중...</div>
+    <div v-else-if="error">데이터가 없습니다.</div>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch, onMounted, onUnmounted, computed } from 'vue'
+import api from '@/api/auth'
+
+const props = defineProps({
+  year: { type: Number, required: true },
+  periodType: { type: String, default: 'month' }, // 'month' | 'quarter' | 'year'
+  periodValue: { type: [Number, String], default: 1 }, // 월/분기 값
+  teamColors: { type: Array, default: () => ['#5470C6', '#91CC75', '#FAC858', '#EE6666', '#73C0DE'] }
+})
+
+const loading = ref(true)
+const error = ref(false)
+const teamNames = ref([])
+const teamAmounts = ref([])
+
+const chartTitle = computed(() => {
+  if (props.periodType === 'month') {
+    return `${props.year}년 ${props.periodValue}월 팀별 매출`
+  } else if (props.periodType === 'quarter') {
+    return `${props.year}년 ${props.periodValue}분기 팀별 매출`
+  } else {
+    return `${props.year}년 팀별 매출`
+  }
+})
+
+let isUnmounted = false
+onUnmounted(() => { isUnmounted = true })
+
+const fetchData = async () => {
+  loading.value = true
+  error.value = false
+  try {
+    let url = ''
+    if (props.periodType === 'month') {
+      url = `/dashboard/sales/amount/monthly/detail?year=${props.year}&month=${props.periodValue}`
+    } else if (props.periodType === 'quarter') {
+      url = `/dashboard/sales/amount/quarterly/detail?year=${props.year}&quarter=${props.periodValue}`
+    } else {
+      url = `/dashboard/sales/amount/yearly/detail?year=${props.year}`
+    }
+    const res = await api.get(url)
+    if (!isUnmounted) {
+      if (Array.isArray(res.data) && res.data.length > 0) {
+        teamNames.value = res.data.map(item => item.teamName)
+        teamAmounts.value = res.data.map(item => item.teamAmount)
+      } else {
+        teamNames.value = []
+        teamAmounts.value = []
+        error.value = true
+      }
+    }
+  } catch (e) {
+    if (!isUnmounted) {
+      teamNames.value = []
+      teamAmounts.value = []
+      error.value = true
+    }
+  } finally {
+    if (!isUnmounted) loading.value = false
+  }
+}
+
+onMounted(fetchData)
+watch(() => [props.year, props.periodType, props.periodValue], fetchData)
+
+const barOption = computed(() => ({
+  tooltip: { trigger: 'axis' },
+  xAxis: {
+    type: 'category',
+    data: teamNames.value
+  },
+  yAxis: {
+    type: 'value',
+    axisLabel: {
+      formatter: function(value) {
+        if (value >= 1e8) return (value / 1e8) + '억'
+        if (value >= 1e4) return (value / 1e4) + '만'
+        return value.toLocaleString()
+      }
+    }
+  },
+  series: [
+    {
+      data: teamAmounts.value,
+      type: 'bar',
+      itemStyle: {
+        color: function(params) {
+          return props.teamColors[params.dataIndex % props.teamColors.length]
+        }
+      },
+      label: {
+        show: true,
+        position: 'top',
+        formatter: function(params) {
+          if (params.value >= 1e8) return (params.value / 1e8) + '억'
+          if (params.value >= 1e4) return (params.value / 1e4) + '만'
+          return params.value.toLocaleString()
+        }
+      },
+      barWidth: 40
+    }
+  ]
+}))
+</script>
+
+<style scoped>
+.team-sales-bar-chart {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+.chart-title {
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 16px;
+}
+</style> 

--- a/src/components/salesDashboard/YearSalesCard.vue
+++ b/src/components/salesDashboard/YearSalesCard.vue
@@ -1,0 +1,109 @@
+<template>
+  <div class="year-sales-card">
+    <div class="title">올해 매출</div>
+    <div class="value">{{ formatCurrency(currentYear) }}</div>
+    <div v-if="!loading && !isNaN(diff) && lastYear > 0" class="diff-text">
+      <span :class="diff > 0 ? 'triangle-up' : diff < 0 ? 'triangle-down' : ''">
+        <template v-if="diff > 0">▲</template>
+        <template v-else-if="diff < 0">▼</template>
+      </span>
+      {{ diffText }}
+    </div>
+    <div class="subtitle">작년 매출</div>
+    <div class="subvalue">{{ formatCurrency(lastYear) }}</div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, computed } from 'vue'
+import api from '@/api/auth'
+
+const currentYear = ref(null)
+const lastYear = ref(null)
+const loading = ref(true)
+
+onMounted(async () => {
+  try {
+    const resYear = await api.get('/dashboard/sales/total?period=year')
+    console.log('올해 매출 응답:', resYear.data)
+    currentYear.value = resYear.data.totalAmount
+    
+    const resLastYear = await api.get('/dashboard/sales/total?period=lastyear')
+    console.log('작년 매출 응답:', resLastYear.data)
+    lastYear.value = resLastYear.data.totalAmount
+  } catch (e) {
+    currentYear.value = 0
+    lastYear.value = 0
+  } finally {
+    loading.value = false
+  }
+})
+
+const diff = computed(() => {
+  if (currentYear.value == null || lastYear.value == null) return NaN
+  return currentYear.value - lastYear.value
+})
+const diffRate = computed(() => {
+  if (currentYear.value == null || lastYear.value == null || lastYear.value === 0) return null
+  return ((diff.value / lastYear.value) * 100).toFixed(1)
+})
+const diffText = computed(() => {
+  if (isNaN(diff.value) || lastYear.value === 0) return '-'
+  const absDiff = Math.abs(diff.value)
+  return `${formatCurrency(absDiff)} (${diffRate.value}%)`
+})
+
+function formatCurrency(val) {
+  if (val == null) return '-'
+  if (val >= 1e8) return (val / 1e8).toFixed(1) + '억원'
+  if (val >= 1e4) return (val / 1e4).toFixed(1) + '만원'
+  return val.toLocaleString() + '원'
+}
+</script>
+
+<style scoped>
+.year-sales-card {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  height: 100%;
+}
+.title {
+  font-size: 18px;
+  color: #333;
+  margin-bottom: 8px;
+}
+.value {
+  font-size: 32px;
+  font-weight: bold;
+  margin-bottom: 8px;
+}
+.diff-text {
+  color: #888;
+  font-size: 15px;
+  margin-bottom: 16px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.triangle-up {
+  color: #2ecc71;
+  font-size: 18px;
+  margin-right: 4px;
+}
+.triangle-down {
+  color: #e74c3c;
+  font-size: 18px;
+  margin-right: 4px;
+}
+.subtitle {
+  font-size: 15px;
+  color: #888;
+  margin-bottom: 4px;
+  margin-top: 70px;
+}
+.subvalue {
+  font-size: 22px;
+  font-weight: 500;
+}
+</style> 

--- a/src/components/salesDashboard/YearlySalesLineChart.vue
+++ b/src/components/salesDashboard/YearlySalesLineChart.vue
@@ -1,0 +1,144 @@
+<template>
+  <div class="yearly-sales-line-chart">
+    <div class="chart-title">{{ year }}년 {{ periodType === 'quarter' ? '분기별' : periodType === 'year' ? '연도별' : '월별' }} 매출 추이</div>
+    <v-chart v-show="!loading && !error" :option="lineOption" autoresize style="height:320px;" />
+    <div v-if="loading">로딩중...</div>
+    <div v-else-if="error">데이터가 없습니다.</div>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch, onMounted, onUnmounted, computed } from 'vue'
+import api from '@/api/auth'
+
+const props = defineProps({
+  year: { type: Number, required: true },
+  periodType: { type: String, default: 'month' } // 'month' | 'quarter' | 'year'
+})
+
+const loading = ref(true)
+const error = ref(false)
+const salesData = ref([])
+
+const xLabels = computed(() => {
+  if (props.periodType === 'quarter') {
+    return ['1분기','2분기','3분기','4분기']
+  } else if (props.periodType === 'year') {
+    // 올해 포함 10년간
+    const thisYear = props.year
+    return Array.from({length: 10}, (_, i) => (thisYear - 9 + i) + '년')
+  } else {
+    return ['1월','2월','3월','4월','5월','6월','7월','8월','9월','10월','11월','12월']
+  }
+})
+
+let isUnmounted = false
+onUnmounted(() => { isUnmounted = true })
+
+const fetchData = async () => {
+  loading.value = true
+  error.value = false
+  try {
+    let url = ''
+    if (props.periodType === 'quarter') {
+      url = `/dashboard/sales/trend/quarterly?year=${props.year}`
+    } else if (props.periodType === 'year') {
+      const thisYear = props.year
+      const startYear = thisYear - 9
+      url = `/dashboard/sales/trend/yearly?startYear=${startYear}&endYear=${thisYear}`
+    } else {
+      url = `/dashboard/sales/trend/monthly?year=${props.year}`
+    }
+    const res = await api.get(url)
+    if (!isUnmounted) {
+      let arr
+      if (props.periodType === 'quarter') {
+        arr = Array(4).fill(0)
+        if (Array.isArray(res.data)) {
+          res.data.forEach(item => {
+            if (item.quarter >= 1 && item.quarter <= 4) {
+              arr[item.quarter - 1] = item.totalAmount
+            }
+          })
+        }
+      } else if (props.periodType === 'year') {
+        // 연간 데이터: 10년간
+        const thisYear = props.year
+        arr = Array(10).fill(0)
+        if (Array.isArray(res.data)) {
+          res.data.forEach(item => {
+            const idx = item.year - (thisYear - 9)
+            if (idx >= 0 && idx < 10) {
+              arr[idx] = item.totalAmount
+            }
+          })
+        }
+      } else {
+        arr = Array(12).fill(0)
+        if (Array.isArray(res.data)) {
+          res.data.forEach(item => {
+            if (item.month >= 1 && item.month <= 12) {
+              arr[item.month - 1] = item.totalAmount
+            }
+          })
+        }
+      }
+      salesData.value = arr
+      if (!arr || arr.every(v => v === 0)) error.value = true
+    }
+  } catch (e) {
+    if (!isUnmounted) {
+      salesData.value = props.periodType === 'quarter' ? Array(4).fill(0) : props.periodType === 'year' ? Array(10).fill(0) : Array(12).fill(0)
+      error.value = true
+    }
+  } finally {
+    if (!isUnmounted) loading.value = false
+  }
+}
+
+onMounted(fetchData)
+watch(() => [props.year, props.periodType], fetchData)
+
+const lineOption = computed(() => ({
+  tooltip: { trigger: 'axis' },
+  xAxis: {
+    type: 'category',
+    data: xLabels.value
+  },
+  yAxis: {
+    type: 'value',
+    axisLabel: {
+      formatter: function(value) {
+        if (value >= 1e8) return (value / 1e8) + '억'
+        if (value >= 1e4) return (value / 1e4) + '만'
+        return value.toLocaleString()
+      }
+    }
+  },
+  series: [
+    {
+      data: salesData.value,
+      type: 'line',
+      smooth: true,
+      symbol: 'circle',
+      areaStyle: { color: 'rgba(84,112,198,0.1)' },
+      lineStyle: { color: '#5470C6' }
+    }
+  ]
+}))
+</script>
+
+<style scoped>
+.yearly-sales-line-chart {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+.chart-title {
+  font-size: 18px;
+  font-weight: 600;
+  margin-bottom: 16px;
+}
+</style> 

--- a/src/config/menuConfig.js
+++ b/src/config/menuConfig.js
@@ -15,8 +15,8 @@ export const menuList = [
       },
       {
         label: "영업부 매출 조회",
-        path: "/dashboard/department",
-        // component: () => import("@/views/dashboard/DepartmentSalesView.vue"),
+        path: "/sales-dashboard",
+        component: () => import("@/views/salesDashboard/SalesDashboardLayout.vue"),
       },
     ],
   },

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -55,7 +55,7 @@ import Breadcrumb from "@/components/Breadcrumb.vue";
 
 .view-area {
   flex: 1;
-  padding: 24px 32px;
+  padding: 0;
   overflow-y: auto;
   background-color: #fff;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -6,8 +6,11 @@ import { useAuthStore } from '@/stores/auth'
 import { useNotificationStore } from '@/stores/notification'
 import '@vueup/vue-quill/dist/vue-quill.snow.css';
 import api from '@/api/auth'
+import VueECharts from 'vue-echarts'
+import * as echarts from 'echarts'
 
 const app = createApp(App)
+app.component('v-chart', VueECharts)
 app.use(createPinia({
   devtools: false
 }))

--- a/src/views/salesDashboard/SalesDashboardLayout.vue
+++ b/src/views/salesDashboard/SalesDashboardLayout.vue
@@ -1,0 +1,410 @@
+<template>
+  <div class="dashboard-container">
+    <div class="dashboard-top">
+      <div class="year-sales">
+        <YearSalesCard />
+      </div>
+      <div class="dashboard-middle">
+        <div class="month-and-quarter-sales">
+          <MonthQuarterSalesCard />
+        </div>
+        <div class="filter-sales">
+          <div class="filter-options-row">
+            <!-- 연도 선택 -->
+            <select v-model="filterYear">
+              <option v-for="year in yearRange" :key="year" :value="year">{{ year }}년</option>
+            </select>
+            <!-- 기간 타입 선택 -->
+            <select v-model="filterPeriodType">
+              <option value="month">월</option>
+              <option value="quarter">분기</option>
+              <option value="year">년</option>
+            </select>
+            <!-- 월/분기/년 옵션 -->
+            <select v-model="filterPeriodValue" :disabled="filterPeriodType === 'year'">
+              <option v-if="filterPeriodType === 'month'" v-for="m in 12" :key="m" :value="m">{{ m }}월</option>
+              <option v-else-if="filterPeriodType === 'quarter'" v-for="q in 4" :key="q" :value="q">{{ q }}분기</option>
+              <option v-else value="">-</option>
+            </select>
+          </div>
+        </div>
+      </div>
+      <div class="condition-graph">
+        <div class="condition-title">{{ conditionGraphTitle }}</div>
+        <v-chart :option="donutOption" autoresize style="height:320px;" />
+      </div>
+    </div>
+    <div class="dashboard-bottom">
+      <div class="sales-progress">
+        <YearlySalesLineChart :year="filterYear" :periodType="filterPeriodType" />
+      </div>
+      <div class="sales-by-teams">
+        <TeamSalesBarChart :year="filterYear" :periodType="filterPeriodType" :periodValue="filterPeriodValue" :teamColors="teamColors" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import YearSalesCard from '@/components/salesDashboard/YearSalesCard.vue'
+import MonthQuarterSalesCard from '@/components/salesDashboard/MonthQuarterSalesCard.vue'
+import YearlySalesLineChart from '@/components/salesDashboard/YearlySalesLineChart.vue'
+import TeamSalesBarChart from '@/components/salesDashboard/TeamSalesBarChart.vue'
+import api from '@/api/auth'
+
+const router = useRouter()
+
+// 기간/연도/월/분기 옵션
+const period = ref('month')
+const selectedYear = ref(new Date().getFullYear())
+const selectedMonth = ref(new Date().getMonth() + 1)
+const selectedQuarter = ref(Math.floor((new Date().getMonth()) / 3) + 1)
+const yearOptions = [2022, 2023, 2024]
+
+// filter-sales용 옵션
+const thisYear = new Date().getFullYear()
+const yearRange = Array.from({length: thisYear - 2010 + 1}, (_, i) => 2010 + i).reverse()
+const filterYear = ref(thisYear)
+const filterPeriodType = ref('month')
+const filterPeriodValue = ref(1)
+
+watch(filterPeriodType, (val) => {
+  if (val === 'month') filterPeriodValue.value = 1
+  else if (val === 'quarter') filterPeriodValue.value = 1
+  else filterPeriodValue.value = ''
+})
+
+const conditionGraphTitle = computed(() => {
+  if (filterPeriodType.value === 'month') {
+    return `${filterYear.value}년 ${filterPeriodValue.value}월 매출`
+  } else if (filterPeriodType.value === 'quarter') {
+    return `${filterYear.value}년 ${filterPeriodValue.value}분기 매출`
+  } else {
+    return `${filterYear.value}년 전체 매출`
+  }
+})
+
+// 영업1팀~5팀 도넛 차트 데이터 (반응형)
+const teamDonutData = ref([])
+const teamColors = ['#5470C6', '#91CC75', '#FAC858', '#EE6666', '#73C0DE']
+
+// filterYear, filterPeriodType, filterPeriodValue 변경 시 API 요청
+watch([filterYear, filterPeriodType, filterPeriodValue], async ([year, type, value]) => {
+  let url = ''
+  if (type === 'month') {
+    url = `/dashboard/sales/ratio/monthly/detail?year=${year}&month=${value}`
+  } else if (type === 'quarter') {
+    url = `/dashboard/sales/ratio/quarterly/detail?year=${year}&quarter=${value}`
+  } else if (type === 'year') {
+    url = `/dashboard/sales/ratio/yearly/detail?year=${year}`
+  }
+  if (url) {
+    try {
+      const res = await api.get(url)
+      if (Array.isArray(res.data)) {
+        teamDonutData.value = res.data.map(item => ({
+          name: item.teamName,
+          value: item.ratio
+        }))
+      } else {
+        teamDonutData.value = []
+      }
+    } catch (e) {
+      teamDonutData.value = []
+      console.error('팀 비중 요청 에러:', e)
+    }
+  }
+}, { immediate: true })
+
+const donutOption = computed(() => ({
+  color: teamColors,
+  tooltip: {
+    trigger: 'item',
+    formatter: '{b}: {d}%'
+  },
+  legend: {
+    show: false
+  },
+  series: [
+    {
+      name: '팀별 비중',
+      type: 'pie',
+      radius: '90%',
+      avoidLabelOverlap: false,
+      label: {
+        show: true,
+        position: 'inside',
+        formatter: '{b}\n{d}%',
+        fontSize: 16,
+        fontWeight: 'bold'
+      },
+      labelLine: { show: false },
+      data: teamDonutData.value
+    }
+  ]
+}))
+
+function goToSales(periodType) {
+  let query = `/sales?period=${periodType}&team=all&year=${selectedYear.value}`
+  if (periodType === 'month') query += `&month=${selectedMonth.value}`
+  if (periodType === 'quarter') query += `&quarter=${selectedQuarter.value}`
+  router.push(query)
+}
+function onLineClick(params) {
+  let idx = params.dataIndex
+  let periodType = period.value
+  let label = lineLabels[periodType][idx]
+  let query = `/sales?period=${periodType}&team=all&year=${selectedYear.value}`
+  if (periodType === 'month') query += `&month=${selectedMonth.value}`
+  if (periodType === 'quarter') query += `&quarter=${selectedQuarter.value}`
+  query += `&label=${label}`
+  router.push(query)
+}
+function onBarClick(params) {
+  let periodType = period.value
+  let query = `/sales?period=${periodType}&team=${params.name}&year=${selectedYear.value}`
+  if (periodType === 'month') query += `&month=${selectedMonth.value}`
+  if (periodType === 'quarter') query += `&quarter=${selectedQuarter.value}`
+  router.push(query)
+}
+
+function formatCurrency(val) {
+  if (val >= 1e8) return (val / 1e8).toFixed(1) + '억원'
+  if (val >= 1e4) return (val / 1e4).toFixed(1) + '만원'
+  return val.toLocaleString() + '원'
+}
+</script>
+
+<style lang="scss" scoped>
+.dashboard-container {
+  padding: 32px;
+  background: #f7f8fa;
+  height: 100vh;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+}
+.dashboard-top, .dashboard-bottom {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  box-sizing: border-box;
+}
+.dashboard-top {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  gap: 24px;
+  flex: 0.5 1 0;
+  min-height: 0;
+}
+.dashboard-bottom {
+  flex: 1 1 0;
+  min-height: 0;
+  margin-top: 24px;
+  gap: 24px;
+}
+.dashboard-middle, .condition-graph {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+  padding: 24px;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  flex: 1 1 0;
+}
+.year-sales {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+  padding: 24px;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  flex: 0.8 1 0;
+}
+.dashboard-middle {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  justify-content: stretch;
+  background: #f7f8fa;
+  border-radius: 0;
+  box-shadow: none;
+  padding: 0;
+}
+.month-and-quarter-sales {
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin-bottom: 8px;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+  padding: 24px;
+}
+.filter-sales {
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+.condition-graph {
+  flex: 1 1 0;
+  margin-left: 0;
+}
+.sales-progress, .sales-by-teams {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+  padding: 24px;
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.dashboard-cards {
+  display: flex;
+  gap: 24px;
+  margin-bottom: 32px;
+}
+.card {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+  padding: 24px 32px;
+  min-width: 220px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  font-size: 18px;
+  cursor: pointer;
+  position: relative;
+}
+.card-title {
+  color: #888;
+  font-size: 15px;
+  margin-bottom: 8px;
+}
+.card-value {
+  font-size: 28px;
+  font-weight: bold;
+}
+.card-donut {
+  position: absolute;
+  right: 16px;
+  bottom: 16px;
+}
+.card-dropdown {
+  min-width: 300px;
+  font-size: 15px;
+  label { margin-right: 8px; }
+  select {
+    margin-right: 16px;
+    padding: 4px 8px;
+    border-radius: 4px;
+    border: 1px solid #ddd;
+  }
+  cursor: default;
+}
+.percent {
+  font-size: 16px;
+  margin-left: 8px;
+}
+.dashboard-charts {
+  display: flex;
+  gap: 32px;
+  margin-bottom: 32px;
+}
+.chart-box {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+  padding: 24px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.chart-title {
+  font-size: 17px;
+  font-weight: 500;
+  margin-bottom: 16px;
+}
+.dashboard-line {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+  padding: 24px;
+  margin-bottom: 32px;
+}
+.filter-options-row {
+  display: flex;
+  flex-direction: row;
+  gap: 1.2rem;
+  align-items: center;
+  background: #fff;
+  border-radius: 0.75rem;
+  box-shadow: 0 0.15em 0.5em rgba(80, 120, 200, 0.07);
+  padding: 1.1em 1.5em;
+  flex-wrap: wrap;
+  border: 1px solid #f0f1f5;
+}
+.filter-options-row select {
+  flex: 1 1 0;
+  min-width: 0;
+  max-width: 100%;
+  appearance: none;
+  background: #f8fafd;
+  border: 1.5px solid #e0e4ea;
+  border-radius: 0.5em;
+  padding: 0.7em 2.2em 0.7em 1em;
+  font-size: 1rem;
+  font-weight: 500;
+  color: #222;
+  box-shadow: 0 0.05em 0.2em rgba(80, 120, 200, 0.04);
+  transition: border 0.18s, box-shadow 0.18s;
+  outline: none;
+  cursor: pointer;
+  background-image: url('data:image/svg+xml;utf8,<svg fill="%2399a" height="20" viewBox="0 0 20 20" width="20" xmlns="http://www.w3.org/2000/svg"><path d="M7.293 8.293a1 1 0 011.414 0L10 9.586l1.293-1.293a1 1 0 111.414 1.414l-2 2a1 1 0 01-1.414 0l-2-2a1 1 0 010-1.414z"/></svg>');
+  background-repeat: no-repeat;
+  background-position: right 0.9em center;
+}
+.filter-options-row select:focus, .filter-options-row select:hover {
+  border: 1.5px solid #5470c6;
+  box-shadow: 0 0.2em 0.6em rgba(84, 112, 198, 0.10);
+  background: #f4f7fd;
+}
+.filter-options-row option {
+  font-size: 0.97rem;
+  color: #333;
+}
+@media (max-width: 600px) {
+  .filter-options-row {
+    flex-direction: column;
+    gap: 0.7em;
+    padding: 0.7em 0.5em;
+  }
+  .filter-options-row select {
+    width: 100%;
+    min-width: 0;
+  }
+}
+.condition-title {
+  font-size: 20px;
+  font-weight: 600;
+  margin-bottom: 16px;
+}
+</style>

--- a/src/views/salesDashboard/SalesDashboardLayout.vue
+++ b/src/views/salesDashboard/SalesDashboardLayout.vue
@@ -30,7 +30,10 @@
         </div>
       </div>
       <div class="condition-graph">
-        <div class="condition-title">{{ conditionGraphTitle }}</div>
+        <div class="condition-title">
+          <span>{{ conditionGraphTitle }}</span>
+          <span class="total-amount">{{ formatCurrency(totalTeamAmount) }}</span>
+        </div>
         <v-chart :option="donutOption" autoresize style="height:320px;" />
       </div>
     </div>
@@ -39,7 +42,7 @@
         <YearlySalesLineChart :year="filterYear" :periodType="filterPeriodType" />
       </div>
       <div class="sales-by-teams">
-        <TeamSalesBarChart :year="filterYear" :periodType="filterPeriodType" :periodValue="filterPeriodValue" :teamColors="teamColors" />
+        <TeamSalesBarChart :year="filterYear" :periodType="filterPeriodType" :periodValue="filterPeriodValue" :teamColors="teamColors" @totalAmount="handleTotalAmount" />
       </div>
     </div>
   </div>
@@ -174,6 +177,11 @@ function formatCurrency(val) {
   if (val >= 1e8) return (val / 1e8).toFixed(1) + '억원'
   if (val >= 1e4) return (val / 1e4).toFixed(1) + '만원'
   return val.toLocaleString() + '원'
+}
+
+const totalTeamAmount = ref(0)
+function handleTotalAmount(val) {
+  totalTeamAmount.value = val
 }
 </script>
 
@@ -406,5 +414,14 @@ function formatCurrency(val) {
   font-size: 20px;
   font-weight: 600;
   margin-bottom: 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.total-amount {
+  font-size: 18px;
+  font-weight: 500;
+  color: #858585;
+  margin-left: 1.5em;
 }
 </style>


### PR DESCRIPTION
## 📌연관된 이슈

> close #155 

## 📝작업 내용

> 이번 PR에서는 매출 대시보드의 모든 주요 기능을 통합적으로 구현하였습니다.

- 연도/기간/월/분기 옵션 필터 UI 및 반응형 적용
- 옵션 변경 시 대시보드 전체 데이터 실시간 갱신
- 도넛 차트(팀별 매출 비중) 및 총 매출 금액 우측 표시
- 팀별 매출 막대 차트 및 합계 계산/전달
- 기간별 매출 추이 꺾은선 그래프
- 올해/작년 매출, 변화율 카드(작년 매출 없을 시 변화율/화살표 미표시)
- 각 차트/카드/필터의 반응형 스타일 및 UX 개선

### 스크린샷 (선택)


1. 2025년 1월 월별 필터
<img width="1718" alt="Image" src="https://github.com/user-attachments/assets/b99276f3-0e7e-47f0-b4e5-11714c525348" />

2. 2025년 1분기 분기별 필터

<img width="1712" alt="Image" src="https://github.com/user-attachments/assets/91bcb446-ac4c-4cdb-98c4-a080116dcd76" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!!
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
