### PR TITLE
[Feat] 헤더의 미리 알림 드롭다운 메뉴와 알림 리스트에서 모두 읽기 버튼 추가

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -3,8 +3,8 @@ import { useAuthStore } from "@/stores/auth";
 
 const BASE_URL =
   //  'http://localhost:5000'
-  //  'http://localhost:5001'
-   'https://api.saladerp.com'
+   'http://localhost:5001'
+  //  'https://api.saladerp.com'
 
 // 일반 요청용 인스턴스
 const api = axios.create({

--- a/src/components/notification/NotificationDropdown.vue
+++ b/src/components/notification/NotificationDropdown.vue
@@ -3,7 +3,10 @@
     <div class="dropdown-arrow"></div>
     <div class="dropdown-header">
       <h3>알림</h3>
-      <button class="view-all-btn" @click="goToNotificationList">전체보기</button>
+      <div class="header-buttons">
+        <button class="mark-all-read-btn" @click="handleMarkAllAsRead" :disabled="unreadNotifications.length === 0">모두 읽기</button>
+        <button class="view-all-btn" @click="goToNotificationList">전체보기</button>
+      </div>
     </div>
     <div class="dropdown-content">
       <div v-if="unreadNotifications.length === 0" class="no-notifications">
@@ -64,6 +67,14 @@ const handleNotificationClick = async (notification) => {
 
 const goToNotificationList = () => {
   router.push('/notification/list')
+}
+
+const handleMarkAllAsRead = async () => {
+  try {
+    await notificationStore.markAllAsRead()
+  } catch (error) {
+    console.error('모든 알림을 읽음 처리하는 중 오류 발생:', error)
+  }
 }
 
 // isOpen prop이 변경될 때마다 알림 목록을 새로고침
@@ -150,6 +161,31 @@ const calculateTimeAgo = (dateString) => {
   font-size: 16px;
   font-weight: 600;
   color: #333;
+}
+
+.header-buttons {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.mark-all-read-btn {
+  background: none;
+  border: none;
+  color: #666;
+  font-size: 13px;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
+.mark-all-read-btn:hover:not(:disabled) {
+  background-color: #f5f5f5;
+}
+
+.mark-all-read-btn:disabled {
+  color: #ccc;
+  cursor: not-allowed;
 }
 
 .view-all-btn {

--- a/src/stores/notification.js
+++ b/src/stores/notification.js
@@ -68,8 +68,7 @@ export const useNotificationStore = defineStore('notification', () => {
       const unreadNotifications = notifications.value.filter(n => !n.read)
       if (unreadNotifications.length === 0) return
 
-      const notificationIds = unreadNotifications.map(n => n.id)
-      await api.patch('/notification/read', notificationIds, {
+      await api.patch('/notification/read-all', null, {
         headers: {
           'Authorization': `Bearer ${auth.accessToken}`
         }

--- a/src/stores/notification.js
+++ b/src/stores/notification.js
@@ -5,8 +5,8 @@ import { useAuthStore } from '@/stores/auth'
 
 const SSE_BASE_URL = 
   //  'http://localhost:5000'
-  //  'http://localhost:5001'
-   'https://api.saladerp.com'
+   'http://localhost:5001'
+  //  'https://api.saladerp.com'
 
 let eventSource = null
 let reconnectTimeout = null
@@ -59,6 +59,31 @@ export const useNotificationStore = defineStore('notification', () => {
       }
     } catch (error) {
 
+    }
+  }
+
+  async function markAllAsRead() {
+    try {
+      const auth = useAuthStore()
+      const unreadNotifications = notifications.value.filter(n => !n.read)
+      if (unreadNotifications.length === 0) return
+
+      const notificationIds = unreadNotifications.map(n => n.id)
+      await api.patch('/notification/read', notificationIds, {
+        headers: {
+          'Authorization': `Bearer ${auth.accessToken}`
+        }
+      })
+      
+      // 모든 읽지 않은 알림을 읽음 상태로 변경
+      notifications.value.forEach(notification => {
+        if (!notification.read) {
+          notification.read = true
+        }
+      })
+      unreadCount.value = 0
+    } catch (error) {
+      console.error('모든 알림을 읽음 처리하는 중 오류 발생:', error)
     }
   }
 
@@ -154,6 +179,7 @@ export const useNotificationStore = defineStore('notification', () => {
     fetchUnreadCount,
     fetchNotifications,
     markAsRead,
+    markAllAsRead,
     deleteNotifications,
     setupSse,
   }

--- a/src/views/notification/NotificationLayout.vue
+++ b/src/views/notification/NotificationLayout.vue
@@ -72,6 +72,12 @@
             
             <div class="delete-actions">
                 <button 
+                    @click="handleMarkAllAsRead" 
+                    class="mark-all-read-button"
+                    :disabled="selectedNotifications.length === 0">
+                    읽음
+                </button>
+                <button 
                     @click="confirmDelete" 
                     class="delete-button"
                     :disabled="selectedNotifications.length === 0">
@@ -288,6 +294,38 @@ const executeDelete = async () => {
     } catch (error) {
         // console.error('알림 삭제 중 오류 발생:', error)
         alert('알림 삭제에 실패했습니다.')
+    }
+}
+
+const handleMarkAllAsRead = async () => {
+    try {
+        if (selectedNotifications.value.length === 0) {
+            alert('읽음 처리할 알림을 선택해주세요.')
+            return
+        }
+
+        const auth = useAuthStore()
+        await api.patch('/notification/read', selectedNotifications.value, {
+            headers: {
+                'Authorization': `Bearer ${auth.accessToken}`
+            }
+        })
+        
+        // 선택된 알림들을 읽음 상태로 변경
+        notifications.value.forEach(notification => {
+            if (selectedNotifications.value.includes(notification.id)) {
+                notification.read = true
+            }
+        })
+        
+        // 선택 해제
+        selectedNotifications.value = []
+        
+        // 목록 새로고침
+        fetchNotifications(currentPage.value)
+    } catch (error) {
+        console.error('선택된 알림을 읽음 처리하는 중 오류 발생:', error)
+        alert('선택된 알림을 읽음 처리하는 중 오류가 발생했습니다.')
     }
 }
 
@@ -594,6 +632,26 @@ onMounted(() => {
 
     &:hover:not(:disabled) {
         background-color: #c82333;
+    }
+
+    &:disabled {
+        background-color: #e9ecef;
+        color: #6c757d;
+        cursor: not-allowed;
+    }
+}
+
+.mark-all-read-button {
+    padding: 8px 16px;
+    background-color: #4a90e2;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 14px;
+
+    &:hover:not(:disabled) {
+        background-color: #357abd;
     }
 
     &:disabled {


### PR DESCRIPTION
## 📌연관된 이슈

> close #204 

## 📝작업 내용

> 헤더의 미리 알림 드롭다운 메뉴와 알림 리스트에서 모두 읽기 버튼 추가

1. 알림 드롭다운 메뉴 개선
전체보기 버튼 왼쪽에 모두 읽기 버튼 추가
읽지 않은 알림이 없을 때 버튼 비활성화

2. 알림 목록 페이지 개선
삭제 버튼 왼쪽에 읽음 버튼 추가
선택된 알림들만 읽음 처리

3. 알림 스토어 기능 확장
markAllAsRead 함수 추가
백엔드 API 연동 및 상태 관리


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요!!
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
