### PR TITLE
[Refactor] 고객 상세 화면에 '취소' 버튼 추가 및 피드백 반영

### DIFF
--- a/src/components/consult/ConsultDetailModal.vue
+++ b/src/components/consult/ConsultDetailModal.vue
@@ -26,7 +26,7 @@
           </div>
 
           <div class.detail-row>
-            <div class="detail-label">피드백 점수</div>
+            <div class="detail-label">만족도</div>
             <div class="detail-value">
               <span v-if="consult.feedbackScore" class="feedback-score">
                 {{ consult.feedbackScore.toFixed(1) }} / 5.0

--- a/src/components/consult/ConsultSearchFields.vue
+++ b/src/components/consult/ConsultSearchFields.vue
@@ -30,7 +30,7 @@
         </div>
       </div>
       <div class="field">
-        <label>피드백 점수</label>
+        <label>만족도</label>
         <div class="star-radios">
           <label v-for="n in 5" :key="n" class="star-label">
             <input type="radio" :value="n" v-model="filters.feedbackScore" />

--- a/src/components/customer/CustomerSearchFields.vue
+++ b/src/components/customer/CustomerSearchFields.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="customer-search-fields">
-    <!-- 첫 번째 행: 고객명, 연락처, 고객 유형, 등록일(시작), 등록일(끝) -->
+    <!-- 첫 번째 행: 고객명, 연락처, 고객 유형, 고객 등록일(범위) -->
     <div class="row">
       <div class="field">
         <label>고객명</label>
@@ -19,23 +19,23 @@
         </select>
       </div>
       <div class="field">
-        <label>고객 등록일(시작)</label>
-        <input type="date" v-model="filters.registerAtFrom" />
-      </div>
-      <div class="field">
-        <label>고객 등록일(끝)</label>
-        <input type="date" v-model="filters.registerAtTo" />
+        <label>고객 등록일</label>
+        <div class="range-inputs">
+          <input type="date" v-model="filters.registerAtFrom" />
+          <span class="tilde">~</span>
+          <input type="date" v-model="filters.registerAtTo" />
+        </div>
       </div>
     </div>
-    <!-- 두 번째 행: 생년월일(시작), 생년월일(끝) -->
+    <!-- 두 번째 행: 생년월일(범위) -->
     <div class="row" v-if="expanded">
       <div class="field">
-        <label>생년월일(시작)</label>
-        <input type="date" v-model="filters.birthdateFrom" />
-      </div>
-      <div class="field">
-        <label>생년월일(끝)</label>
-        <input type="date" v-model="filters.birthdateTo" />
+        <label>생년월일</label>
+        <div class="range-inputs">
+          <input type="date" v-model="filters.birthdateFrom" />
+          <span class="tilde">~</span>
+          <input type="date" v-model="filters.birthdateTo" />
+        </div>
       </div>
     </div>
   </div>
@@ -89,6 +89,20 @@ select:focus {
   outline: none;
   border-color: #86b649;
   box-shadow: 0 0 0 2px rgba(134, 182, 73, 0.1);
+}
+.range-inputs {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.range-inputs input {
+  flex: 1;
+  min-width: 0;
+}
+.tilde {
+  font-size: 12px;
+  color: #666;
+  flex-shrink: 0;
 }
 @media (max-width: 1200px) {
   .row {

--- a/src/views/consult/ConsultDetailView.vue
+++ b/src/views/consult/ConsultDetailView.vue
@@ -81,14 +81,10 @@
                         : "")
                 }}
               </span>
-              <span class="consult-meta-pill"
-                ><b>상담일:</b>
-                {{
-                  form.consultAt
-                    ? form.consultAt.split("T")[0].replace(/-/g, ". ")
-                    : "-"
-                }}</span
-              >
+              <span class="consult-meta-pill">
+                <b>상담 일시:</b>
+                {{ formatDateTime(form.consultAt) }}
+              </span>
             </div>
           </div>
           <div class="form-group">
@@ -255,6 +251,19 @@ const handleDelete = async () => {
     isSubmitting.value = false;
   }
 };
+
+function formatDateTime(dateString) {
+  if (!dateString) return "-";
+  const date = new Date(dateString);
+  const yyyy = date.getFullYear();
+  const MM = String(date.getMonth() + 1).padStart(2, "0");
+  const dd = String(date.getDate()).padStart(2, "0");
+  const HH = String(date.getHours()).padStart(2, "0");
+  const mm = String(date.getMinutes()).padStart(2, "0");
+  const weekNames = ["일", "월", "화", "수", "목", "금", "토"];
+  const ddd = weekNames[date.getDay()];
+  return `${yyyy}-${MM}-${dd}(${ddd}) ${HH}:${mm}`;
+}
 </script>
 
 <style scoped>

--- a/src/views/consult/ConsultDetailView.vue
+++ b/src/views/consult/ConsultDetailView.vue
@@ -271,12 +271,14 @@ function formatDateTime(dateString) {
   padding: 24px;
 }
 .form-container {
-  border-radius: 8px;
+  gap: 24px;
 }
 .section {
-  border-radius: 6px;
-  padding: 24px;
-  margin-bottom: 32px;
+  background: white;
+  border-radius: 8px;
+  padding: 20px;
+  border: 1px solid #e9ecef;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
 }
 .section-header {
   display: flex;
@@ -398,12 +400,6 @@ function formatDateTime(dateString) {
   display: flex;
   align-items: center;
 }
-.section-consult-content {
-  background: #fafafa;
-  border-radius: 12px;
-  padding: 24px 24px 32px 24px;
-  margin-bottom: 32px;
-}
 .consult-title-row {
   display: flex;
   align-items: center;
@@ -443,5 +439,8 @@ function formatDateTime(dateString) {
 .delete-btn:disabled {
   background-color: #ccc;
   cursor: not-allowed;
+}
+.consult-detail-view .section {
+  margin-bottom: 24px;
 }
 </style>

--- a/src/views/consult/ConsultRegister.vue
+++ b/src/views/consult/ConsultRegister.vue
@@ -37,7 +37,6 @@
               </select>
             </div>
             <div class="form-item">
-              ₩ㅐㅐㅣ₩8
               <label>고객 등록일</label>
               <input
                 type="date"

--- a/src/views/consult/ConsultRegister.vue
+++ b/src/views/consult/ConsultRegister.vue
@@ -145,18 +145,15 @@ const handleCancel = () => {
 .consult-register-view {
   padding: 24px;
 }
-.form-container {
-  background-color: #fff;
-  border-radius: 8px;
-  padding: 24px;
-  border: 1px solid #eee;
+.consult-register-view .section {
+  margin-bottom: 24px;
 }
 .section {
-  background-color: #fff;
-  border-radius: 6px;
-  padding: 24px;
-  margin-bottom: 32px;
-  box-shadow: 0 0 4px rgba(0, 0, 0, 0.03);
+  background: white;
+  border-radius: 8px;
+  padding: 20px;
+  border: 1px solid #e9ecef;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
 }
 .section-header {
   display: flex;

--- a/src/views/consult/ConsultingView.vue
+++ b/src/views/consult/ConsultingView.vue
@@ -66,16 +66,23 @@ const columns = ref([
   { key: "consultAt", label: "상담 일자", width: "180px" },
   { key: "content", label: "상담 내용", width: "300px" },
   { key: "customerName", label: "고객명", width: "130px" },
-  { key: "feedbackScore", label: "피드백 점수", width: "120px" },
+  { key: "feedbackScore", label: "만족도", width: "120px" },
   { key: "etc", label: "비고", width: "200px" },
 ]);
+
+function formatDateTime(dateString) {
+  if (!dateString) return "-";
+  const date = new Date(dateString);
+  const yyyy = date.getFullYear();
+  const MM = String(date.getMonth() + 1).padStart(2, "0");
+  const dd = String(date.getDate()).padStart(2, "0");
+  return `${yyyy}-${MM}-${dd}`;
+}
 
 const formattedConsults = computed(() => {
   return consults.value.map((c) => ({
     ...c,
-    consultAt: c.consultAt
-      ? new Date(c.consultAt).toLocaleString("ko-KR")
-      : "-",
+    consultAt: formatDateTime(c.consultAt),
     feedbackScore: c.feedbackScore ? c.feedbackScore.toFixed(1) : "-",
     customerName: c.customerName || "-",
   }));

--- a/src/views/customer/CustomerDetail.vue
+++ b/src/views/customer/CustomerDetail.vue
@@ -4,10 +4,6 @@
     <div class="section" v-if="customer">
       <div class="section-header">
         <h2 class="section-title">기본 정보 <span class="required">*</span></h2>
-        <div class="section-actions">
-          <button class="button primary" @click="handleUpdate">수정</button>
-          <button class="button danger" @click="handleDelete">삭제</button>
-        </div>
       </div>
       <div class="form-grid">
         <div class="form-item">
@@ -56,6 +52,11 @@
           <textarea rows="3" v-model="customer.etc" />
         </div>
       </div>
+      <div class="form-actions">
+        <button class="submit-btn" @click="handleUpdate">수정</button>
+        <button class="delete-btn" @click="handleDelete">삭제</button>
+        <button class="cancel-btn" @click="handleCancel">취소</button>
+      </div>
     </div>
     <div v-else class="loading-message">고객 정보를 불러오는 중입니다...</div>
 
@@ -82,7 +83,7 @@
             @dblclick="handleConsultRowDblClick(consult)"
             class="clickable-row"
           >
-            <td>{{ consult.consultAt }}</td>
+            <td>{{ formatDateTime(consult.consultAt) }}</td>
             <td>{{ consult.employeeName }}</td>
             <td>{{ consult.content }}</td>
             <td>{{ consult.feedbackScore }}</td>
@@ -178,6 +179,10 @@ const handleDelete = async () => {
   }
 };
 
+const handleCancel = () => {
+  router.push("/customer");
+};
+
 const handleConsultRowDblClick = (consult) => {
   // 관리자 여부 확인
   const isAdmin = ["관리자", "admin", "Admin"].includes(
@@ -190,6 +195,15 @@ const handleConsultRowDblClick = (consult) => {
     alert("본인이 작성한 상담만 상세 조회할 수 있습니다.");
   }
 };
+
+function formatDateTime(dateString) {
+  if (!dateString) return "-";
+  const date = new Date(dateString);
+  const yyyy = date.getFullYear();
+  const MM = String(date.getMonth() + 1).padStart(2, "0");
+  const dd = String(date.getDate()).padStart(2, "0");
+  return `${yyyy}-${MM}-${dd}`;
+}
 </script>
 
 <style scoped>
@@ -340,5 +354,49 @@ const handleConsultRowDblClick = (consult) => {
   text-align: center;
   color: #888;
   font-size: 16px;
+}
+
+.submit-btn,
+.cancel-btn {
+  padding: 10px 20px;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+}
+.submit-btn {
+  background-color: #86b649;
+  color: white;
+}
+.submit-btn:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+}
+.cancel-btn {
+  background-color: #f5f5f5;
+  color: #666;
+  border: 1px solid #ddd;
+}
+.delete-btn {
+  background-color: #e57373;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  padding: 10px 20px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+}
+.delete-btn:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 24px;
 }
 </style>

--- a/src/views/customer/CustomerDetail.vue
+++ b/src/views/customer/CustomerDetail.vue
@@ -215,9 +215,11 @@ function formatDateTime(dateString) {
 
 /* 공통 섹션 박스 */
 .section {
-  border-radius: 6px;
-  padding: 24px;
-  margin-bottom: 32px;
+  background: white;
+  border-radius: 8px;
+  padding: 20px;
+  border: 1px solid #e9ecef;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
 }
 
 /* 섹션 제목 및 버튼 영역 */
@@ -398,5 +400,9 @@ function formatDateTime(dateString) {
   justify-content: flex-end;
   gap: 12px;
   margin-top: 24px;
+}
+
+.customer-detail > .section {
+  margin-bottom: 24px;
 }
 </style>

--- a/src/views/customer/CustomerView.vue
+++ b/src/views/customer/CustomerView.vue
@@ -105,7 +105,10 @@ const formatCustomerType = (type) => {
 const formatDate = (dateString) => {
   if (!dateString) return "-";
   const date = new Date(dateString);
-  return date.toLocaleDateString("ko-KR");
+  const yyyy = date.getFullYear();
+  const MM = String(date.getMonth() + 1).padStart(2, "0");
+  const dd = String(date.getDate()).padStart(2, "0");
+  return `${yyyy}-${MM}-${dd}`;
 };
 
 fetchCustomers();


### PR DESCRIPTION
## 📝작업 내용

- 고객 상세 화면에 '취소(목록으로 돌아가기)' 버튼 추가

<img width="235" alt="image" src="https://github.com/user-attachments/assets/1f863baa-bdb0-4cf5-bb6a-77337a78a1ff" />

- 상담 등록 화면에서 고객 등록일 필드 위 문자 제거
- 상담 상세 화면 제외 고객 관리, 고객 상세, 상담 관리 화면의 일자 포맷을 yyyy-MM-dd로 수정

<img width="308" alt="image" src="https://github.com/user-attachments/assets/84b3e463-52d0-414d-8976-e228eea6cede" />

<img width="128" alt="image" src="https://github.com/user-attachments/assets/55c80c6f-18f0-4111-811d-19feb8fcd179" />

<img width="260" alt="image" src="https://github.com/user-attachments/assets/27355c52-e337-4fac-8829-32b49e040f98" />

  - 상담 상세에서는 yyyy-MM-dd(ddd) HH:mm

<img width="547" alt="image" src="https://github.com/user-attachments/assets/fcb3c30b-9a44-4dc0-b874-b51802cf8244" />

- 고객 관리 검색 필드 중 고객 등록일, 생년월일을 범위 형태로 표시되도록 수정

<img width="300" alt="image" src="https://github.com/user-attachments/assets/5f994988-512c-4c6e-b3c0-1761ece579ea" />
<img width="287" alt="image" src="https://github.com/user-attachments/assets/967637d5-9d19-447d-80d9-5e3daa1313d9" />

- 고객 관리, 상담 상세, 상담 등록 화면의 section을 구분하도록 css 수정